### PR TITLE
Add working Dockerfile and compose setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+    "name": "psat-server-web",
+    "build": {
+        "dockerfile": "../Dockerfile",
+        "context": ".."
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.debugpy",
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "esbenp.prettier-vscode",
+                "dbaeumer.vscode-eslint"
+            ],
+            "settings": {
+                "terminal.integrated.shell.linux": "/bin/bash",
+                "python.languageServer": "Pylance",
+                "python.testing.pytestEnabled": true
+            }
+        }
+    }
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Ignore all docker-related files to prevent the image from rebuilding
+# unnecessarily (as we're copying the entire directory into the image)
+Dockerfile
+docker-compose.yml
+.env
+.dockerignore
+data/
+.devcontainer/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM python:3.9
+
+RUN useradd \
+--create-home \  
+--shell /bin/bash \
+--uid 1001 \
+--user-group \
+psat 
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Install system dependencies and then remove cache to reduce image size
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    pkg-config \
+    apache2-dev \
+    libhdf5-dev \
+    default-libmysqlclient-dev \
+    swig \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the parent directory (the repo) contents into the container at /app
+COPY . .
+
+# Install python dependencies and the package itself
+RUN pip install --no-cache-dir -e . && \
+    pip install --no-cache-dir mod_wsgi-standalone
+
+WORKDIR /app/psat_server_web/atlas
+
+# Link to the images dir and change ownership of everything in the app directory 
+# to the psat user
+RUN ln -s /images /app/psat_server_web/atlas/media/images/data && \
+    chown -R psat:psat /app
+      
+
+USER 1001
+
+# Set the command to run on container start
+CMD ["bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,66 @@
+services:
+  db: 
+    image: mariadb:latest
+    hostname: db
+    ports:
+      - 3306:3306
+    volumes:
+      - ./docker/my.cnf:/etc/mysql/my.cnf
+      # - db_data:/var/lib/mysql
+      # - ./data/db_data:/var/db_data
+      - ./data/init.sql:/docker-entrypoint-initdb.d/1.sql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MARAIDB_DATABASE: ${MYSQL_DATABASE}
+    healthcheck:
+      test: ["CMD", "mysql", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}", "-e", "SELECT 1"]
+      timeout: 20s
+      retries: 10
+
+  adminer:
+    depends_on:
+      - db
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080
+
+  atlas-web:
+    build: .
+    command: sh -c "python manage.py collectstatic --noinput && python manage.py migrate --noinput && ./generate_mod_wsgi_apachectl.sh && sleep infinity"
+    hostname: psat-server-web
+    restart: always
+    volumes:
+      - ./data/db_data:/images 
+    #   - .:/app
+    ports:
+      - 8086:8086
+    depends_on:
+      - db
+    environment:
+      - WSGI_PREFIX=/atlas
+      - DJANGO_MYSQL_DBNAME=${MYSQL_DATABASE}
+      - DJANGO_MYSQL_DBUSER=${DJANGO_MYSQL_DBUSER}
+      - DJANGO_MYSQL_DBPASS=${MYSQL_PASSWORD}
+      - DJANGO_MYSQL_DBHOST=db
+      - DJANGO_MYSQL_DBPORT=3306
+      - DJANGO_SECRET_KEY=secret
+      - DJANGO_TNS_DAEMON_SERVER=psat-server-web
+      - DJANGO_TNS_DAEMON_PORT=8001
+      - DJANGO_MPC_DAEMON_SERVER=psat-server-web
+      - DJANGO_MPC_DAEMON_PORT=8002
+      - DJANGO_NAME_DEAMON_SERVER=psat-server-web
+      - DJANGO_NAME_DEAMON_PORT=8003
+      - DJANGO_NAMESERVER_MULTIPLIER=10000000
+      - DJANGO_NAMESERVER_TOKEN=''
+      - DJANGO_NAMESERVER_API_URL=''
+      - DJANGO_LASAIR_TOKEN=${DJANGO_LASAIR_TOKEN}
+      - DJANGO_DUSTMAP_LOCATION=/tmp/dustmap
+
+
+volumes:
+  db_data:
+     

--- a/docker/my.cnf
+++ b/docker/my.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+
+innodb_log_file_size = 512M
+innodb_strict_mode = 0


### PR DESCRIPTION
This adds the complement of files for running a local server with docker compose. Still requires dummy database .sql file and images to get a fully functional local version. 

Works simply by running 
``` bash
docker compose up
``` 

The compose file assumes the `init.sql` file and `db_data` folder are in a folder `/data` off of the root of the repo. 