### PR TITLE
Rate limiting on API and Web-based Permissions Restrictions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Stop containers
       if: always()
       run: docker compose down
-  testing-pip:
+  test-pip-install:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -65,7 +65,3 @@ jobs:
       run: |
         # Copy the sample environment file
         cp .env.sample .env
-    - name: Run tests
-      run: |
-        python psat_server_web/atlas/manage.py makemigrations --noinput
-        python psat_server_web/atlas/manage.py test --noinput

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - ./data/db_data:/images 
       - ./psat_server_web/atlas/atlasapi:/app/psat_server_web/atlas/atlasapi
       - ./psat_server_web/atlas/atlas:/app/psat_server_web/atlas/atlas
+      - ./psat_server_web/atlas/templates:/app/psat_server_web/atlas/templates
       - ./psat_server_web/atlas/accounts:/app/psat_server_web/atlas/accounts
       - ./psat_server_web/atlas/tests:/app/psat_server_web/atlas/tests
     ports:

--- a/psat_server_web/atlas/atlas/permissions.py
+++ b/psat_server_web/atlas/atlas/permissions.py
@@ -11,7 +11,7 @@ def has_write_permissions(user: User) -> bool:
         logger.debug("User is not authenticated.")
         return False
     
-    return user.has_perm('atlas.has_write_access') or user.is_staff or user.is_staff
+    return user.has_perm('atlas.has_write_access') or user.is_staff or user.is_superuser
 
 
 class GlobalPermissions(models.Model):

--- a/psat_server_web/atlas/atlas/permissions.py
+++ b/psat_server_web/atlas/atlas/permissions.py
@@ -1,0 +1,29 @@
+import logging 
+
+from django.contrib.auth.models import User
+from django.db import models
+
+logger = logging.getLogger(__name__)
+
+def has_write_permissions(user: User) -> bool:
+    """Check if the user has permission to edit observation data"""
+    if not user.is_authenticated:
+        logger.debug("User is not authenticated.")
+        return False
+    
+    return user.has_perm('atlas.has_write_access') or user.is_staff or user.is_staff
+
+
+class GlobalPermissions(models.Model):
+    """
+    A dummy model used solely for global permissions.
+    This model does not store any data, but is simply used to define
+    global permissions for the application.
+    """
+
+    class Meta:
+        managed = False
+        default_permissions = ()
+        permissions = (
+            ('has_write_access', 'Write permission: can add and update observations'),
+        )

--- a/psat_server_web/atlas/atlas/settings.py
+++ b/psat_server_web/atlas/atlas/settings.py
@@ -232,5 +232,18 @@ INSTALLED_APPS = [
     'rest_framework.authtoken',
 ]
 
+REST_FRAMEWORK = {
+    'DEFAULT_THROTTLE_CLASSES': [
+        'atlasapi.throttling.BurstRateThrottle',        # For authenticated users
+        'atlasapi.throttling.UserAdminRateThrottle',    # Allow admin users unlimited rate, otherwise use the default rate 
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '50/day',       # The only anonymous endpoint is the token refresh endpoint
+        'user': '1000/day',     # Limit regular authenticated users to 1000 requests per day
+        'admin': '100000/day',  # Allow admin users (basically) unlimited rate
+        'burst': '120/min',     # Also limit all authenticated users to 1000 requests per minute
+    }
+}
+
 # Token expiry time in days, default 1 day (24*60*60 seconds)
 TOKEN_EXPIRY = int(os.environ.get("API_TOKEN_EXPIRY") or 86400) # seconds

--- a/psat_server_web/atlas/atlas/settings.py
+++ b/psat_server_web/atlas/atlas/settings.py
@@ -238,10 +238,10 @@ REST_FRAMEWORK = {
         'atlasapi.throttling.UserAdminRateThrottle',    # Allow admin users unlimited rate, otherwise use the default rate 
     ],
     'DEFAULT_THROTTLE_RATES': {
-        'anon': '50/day',       # The only anonymous endpoint is the token refresh endpoint
-        'user': '1000/day',     # Limit regular authenticated users to 1000 requests per day
-        'admin': '100000/day',  # Allow admin users (basically) unlimited rate
-        'burst': '120/min',     # Also limit all authenticated users to 1000 requests per minute
+        'anon': '10/hour',       # The only anonymous endpoint is the token refresh endpoint
+        'user': '100/hour',      # Limit regular authenticated users to 100 requests per hour
+        'admin': '100000/hour',  # Allow admin users (basically) unlimited rate
+        'burst': '60/min',       # Also limit all authenticated users to 60 requests per minute
     }
 }
 

--- a/psat_server_web/atlas/atlas/settings.py
+++ b/psat_server_web/atlas/atlas/settings.py
@@ -234,14 +234,12 @@ INSTALLED_APPS = [
 
 REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_CLASSES': [
-        'atlasapi.throttling.BurstRateThrottle',        # For authenticated users
         'atlasapi.throttling.UserAdminRateThrottle',    # Allow admin users unlimited rate, otherwise use the default rate 
     ],
     'DEFAULT_THROTTLE_RATES': {
         'anon': '10/hour',       # The only anonymous endpoint is the token refresh endpoint
         'user': '100/hour',      # Limit regular authenticated users to 100 requests per hour
         'admin': '100000/hour',  # Allow admin users (basically) unlimited rate
-        'burst': '60/min',       # Also limit all authenticated users to 60 requests per minute
     }
 }
 

--- a/psat_server_web/atlas/atlas/views.py
+++ b/psat_server_web/atlas/atlas/views.py
@@ -87,7 +87,7 @@ import django_tables2 as tables2
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 # 2016-02-26 KWS Required for authentication
-from django.contrib.auth.decorators import login_required, permission_required
+from django.contrib.auth.decorators import login_required
 
 # 2022-05-06 KWS New model - AtlasDiffSubcells
 from atlas.models import AtlasDiffSubcells
@@ -1357,7 +1357,7 @@ def candidateddc(request, atlas_diff_objects_id, template_name):
     formSearchObject = SearchForObjectForm()
     form = PromoteAndCommentsForm()
 
-    if request.method == 'POST' and can_edit_fl:
+    if request.method == 'POST':
         logger.debug("In a POST request")
         if 'find_object' in request.POST:
             formSearchObject = SearchForObjectForm(request.POST)
@@ -1368,7 +1368,7 @@ def candidateddc(request, atlas_diff_objects_id, template_name):
                     listHeader = 'Candidates for Followup'
                 else:
                     objectsQueryset = AtlasDiffObjects.objects.filter(detection_list_id = listNumber, images_id__isnull = False)
-        else:
+        elif can_edit_fl:
             form = PromoteAndCommentsForm(request.POST)
             if form.is_valid(): # All validation rules pass
                 # Do stuff here

--- a/psat_server_web/atlas/atlas/views.py
+++ b/psat_server_web/atlas/atlas/views.py
@@ -86,7 +86,7 @@ import django_tables2 as tables2
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 # 2016-02-26 KWS Required for authentication
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, permission_required
 
 # 2022-05-06 KWS New model - AtlasDiffSubcells
 from atlas.models import AtlasDiffSubcells
@@ -1139,6 +1139,7 @@ def addVraRow(objectid, originalListId, destinationListId, username, settings):
 
 # 2017-06-16 KWS New DDC format candidate method
 @login_required
+@permission_required('atlas.add_atlasdiffobjects')
 def candidateddc(request, atlas_diff_objects_id, template_name):
     """candidateddc.
 

--- a/psat_server_web/atlas/atlas/views.py
+++ b/psat_server_web/atlas/atlas/views.py
@@ -13,6 +13,7 @@ from django.template.context_processors import csrf
 from django.urls import reverse
 from django.db.models import Avg, Max, Min, Count
 from django.db import IntegrityError
+from .permissions import has_write_permissions
 from atlas.models import TcsPostageStampImages
 from atlas.models import TcsClassificationFlags
 from atlas.models import TcsDetectionLists
@@ -104,6 +105,10 @@ from requests.exceptions import Timeout as RequestsConnectionTimeoutError
 # 2023-01-06 KWS Import the new code to grab a name from the nameserver.
 #                Requires an update to gkutils.
 from gkutils.commonutils import getLocalObjectName
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class LoginForm(forms.Form):
@@ -1139,7 +1144,6 @@ def addVraRow(objectid, originalListId, destinationListId, username, settings):
 
 # 2017-06-16 KWS New DDC format candidate method
 @login_required
-@permission_required('atlas.add_atlasdiffobjects')
 def candidateddc(request, atlas_diff_objects_id, template_name):
     """candidateddc.
 
@@ -1153,6 +1157,7 @@ def candidateddc(request, atlas_diff_objects_id, template_name):
 
     transient = get_object_or_404(AtlasDiffObjects, pk=atlas_diff_objects_id)
 
+    can_edit_fl = has_write_permissions(request.user)
 
     # 2015-11-17 KWS Get the processing status. If it's not 2, what is it?
     processingStatusData = TcsProcessingStatus.objects.all().exclude(status = 2)
@@ -1161,6 +1166,11 @@ def candidateddc(request, atlas_diff_objects_id, template_name):
     if len(processingStatusData) == 1:
         processingStatus = processingStatusData[0].status
         processingStartTime = processingStatusData[0].started
+        
+    if processingStatus == 1:
+        # No one should be able to edit this object when processing happening.
+        can_edit_fl = False
+    logger.debug("User can edit observations: %s" % can_edit_fl)
 
     # 2017-03-21 KWS Get Gravity Wave annotations and Sherlock Classifications
     sc = SherlockClassifications.objects.filter(transient_object_id_id = transient.id)
@@ -1347,7 +1357,8 @@ def candidateddc(request, atlas_diff_objects_id, template_name):
     formSearchObject = SearchForObjectForm()
     form = PromoteAndCommentsForm()
 
-    if request.method == 'POST':
+    if request.method == 'POST' and can_edit_fl:
+        logger.debug("In a POST request")
         if 'find_object' in request.POST:
             formSearchObject = SearchForObjectForm(request.POST)
             if formSearchObject.is_valid(): # All validation rules pass
@@ -1669,8 +1680,41 @@ def candidateddc(request, atlas_diff_objects_id, template_name):
                 rmsScatter += xmrmsScatter
 
     recurrenceData = [recurrencePlotData, recurrencePlotLabels, averageObjectCoords, rmsScatter]
+    
+    context = {
+        'transient' : transient, 
+        'table': table, 
+        'images': transient_images, 
+        'form' : form, 
+        'avg_coords': avgCoords, 
+        'lcdata': lcData, 
+        'lcdataforced': lcDataForced, 
+        'lcdataforcedflux': lcDataForcedFlux, 
+        'lcdataforcedstackflux': lcDataForcedStackFlux, 
+        'lclimits': lcLimits, 
+        'recurrencedata': recurrenceData, 
+        'conesearchold': xmresults['oldDBXmList'], 
+        'olddburl': xmresults['oldDBURL'], 
+        'externalXMs': externalXMs, 
+        'tnsXMs': tnsXMs, 
+        'public': public, 
+        'form_searchobject': formSearchObject, 
+        'dbName': dbName, 
+        'finderImages': finderImages, 
+        'processingStatus': processingStatus, 
+        'galactic': galactic, 
+        'fpData': fpData, 
+        'sc': sc, 
+        'gw': gw, 
+        'comments': existingComments, 
+        'sx': sx, 
+        'lasairZTFCrossmatches': lasairZTFCrossmatches, 
+        'panstarrsCrossmatches': panstarrsCrossmatches, 
+        'panstarrsBaseURL': settings.PANSTARRS_BASE_URL,
+        'can_edit_fl': can_edit_fl,
+    }
 
-    return render(request, 'atlas/' + template_name,{'transient' : transient, 'table': table, 'images': transient_images, 'form' : form, 'avg_coords': avgCoords, 'lcdata': lcData, 'lcdataforced': lcDataForced, 'lcdataforcedflux': lcDataForcedFlux, 'lcdataforcedstackflux': lcDataForcedStackFlux, 'lclimits': lcLimits, 'recurrencedata': recurrenceData, 'conesearchold': xmresults['oldDBXmList'], 'olddburl': xmresults['oldDBURL'], 'externalXMs': externalXMs, 'tnsXMs': tnsXMs, 'public': public, 'form_searchobject': formSearchObject, 'dbName': dbName, 'finderImages': finderImages, 'processingStatus': processingStatus, 'galactic': galactic, 'fpData': fpData, 'sc': sc, 'gw': gw, 'comments': existingComments, 'sx': sx, 'lasairZTFCrossmatches': lasairZTFCrossmatches, 'panstarrsCrossmatches': panstarrsCrossmatches, 'panstarrsBaseURL': settings.PANSTARRS_BASE_URL})
+    return render(request, 'atlas/' + template_name, context)
 
 
 def lightcurveplain(request, tcs_transient_objects_id):
@@ -3167,6 +3211,8 @@ def followupQuickView(request, listNumber):
 
     detectionListRow = get_object_or_404(TcsDetectionLists, pk=listNumber)
     listHeader = detectionListRow.description
+    
+    can_edit_fl = has_write_permissions(request.user)
 
     # We just want to pass the list Id to the HTML page, if it exists
     list_id = None
@@ -3206,38 +3252,33 @@ def followupQuickView(request, listNumber):
         processingStatus = processingStatusData[0].status
         processingStartTime = processingStatusData[0].started
 
+    if processingStatus == 1:
+        can_edit_fl = False
+    logger.debug("User can edit observations: %s" % can_edit_fl)
+    
+    objectsQueryset = None
+        
     objectName = None
 
     # Dummy form search object
     formSearchObject = SearchForObjectForm()
 
     coneSearchRadius = 3.6
-    if request.method == 'POST':
-        if 'find_object' in request.POST:
-            formSearchObject = SearchForObjectForm(request.POST)
-            if formSearchObject.is_valid(): # All validation rules pass
-                objectName = formSearchObject.cleaned_data['searchText']
-                objectsQueryset = processSearchForm(objectName)
+    # Search for object name
+    if request.method == 'POST' and 'find_object' in request.POST:
+        formSearchObject = SearchForObjectForm(request.POST)
+        if formSearchObject.is_valid(): # All validation rules pass
+            objectName = formSearchObject.cleaned_data['searchText']
+            objectsQueryset = processSearchForm(objectName)
 #                if len(objectName) > 0 and objectName != '%%':
 #                    objectsQueryset = AtlasDiffObjects.objects.filter(Q(atlas_designation__isnull = False) & (Q(atlas_designation__startswith = objectName) | Q(other_designation__startswith = objectName)))
 #                    listHeader = 'Candidates for Followup'
 #                else:
 #                    objectsQueryset = AtlasDiffObjects.objects.filter(detection_list_id = listNumber, images_id__isnull = False)
-            else: # Default query if the form is NOT valid - need to fix!!
-                #objectsQueryset = AtlasDiffObjects.objects.filter(detection_list_id = listNumber, images_id__isnull = False)
-                # 2019-07-31 KWS Rattle through all the objects to see if we have any
-                #                associated with a specified GW event.
-                if queryFilterGW:
-                    gw = TcsGravityEventAnnotations.objects.filter(transient_object_id__detection_list_id=list_id).filter(**queryFilterGW)
-                    gwTaggedObjects = [x.transient_object_id_id for x in gw]
-                    if len(gwTaggedObjects) == 0:
-                        # Put one fake object in the list. The query will fail with an EmptyResultSet error if we don't.
-                        gwTaggedObjects = [1]
-                    objectsQueryset = AtlasDiffObjects.objects.filter(**queryFilter).filter(id__in=gwTaggedObjects)
-                else:
-                    objectsQueryset = AtlasDiffObjects.objects.filter(**queryFilter)
-        else:
-            # We're using the submit form for the object updates
+        else: # Default query if the form is NOT valid - need to fix!!
+            #objectsQueryset = AtlasDiffObjects.objects.filter(detection_list_id = listNumber, images_id__isnull = False)
+            # 2019-07-31 KWS Rattle through all the objects to see if we have any
+            #                associated with a specified GW event.
             if queryFilterGW:
                 gw = TcsGravityEventAnnotations.objects.filter(transient_object_id__detection_list_id=list_id).filter(**queryFilterGW)
                 gwTaggedObjects = [x.transient_object_id_id for x in gw]
@@ -3247,57 +3288,69 @@ def followupQuickView(request, listNumber):
                 objectsQueryset = AtlasDiffObjects.objects.filter(**queryFilter).filter(id__in=gwTaggedObjects)
             else:
                 objectsQueryset = AtlasDiffObjects.objects.filter(**queryFilter)
+    # Otherwise classify, but only if we have edit permissions
+    elif request.method == 'POST' and can_edit_fl:
+        # We're using the submit form for the object updates
+        if queryFilterGW:
+            gw = TcsGravityEventAnnotations.objects.filter(transient_object_id__detection_list_id=list_id).filter(**queryFilterGW)
+            gwTaggedObjects = [x.transient_object_id_id for x in gw]
+            if len(gwTaggedObjects) == 0:
+                # Put one fake object in the list. The query will fail with an EmptyResultSet error if we don't.
+                gwTaggedObjects = [1]
+            objectsQueryset = AtlasDiffObjects.objects.filter(**queryFilter).filter(id__in=gwTaggedObjects)
+        else:
+            objectsQueryset = AtlasDiffObjects.objects.filter(**queryFilter)
 
-            for key, value in list(request.POST.items()):
-                if '_promote_demote' in key and value != 'U':
+        for key, value in list(request.POST.items()):
+            if '_promote_demote' in key and value != 'U':
 
-                    id = int(key.replace('_promote_demote', ''))
+                id = int(key.replace('_promote_demote', ''))
 
-                    transient = AtlasDiffObjects.objects.get(pk=id)
-                    originallistId = transient.detection_list_id.id
+                transient = AtlasDiffObjects.objects.get(pk=id)
+                originallistId = transient.detection_list_id.id
 
-                    # 2017-10-04 KWS Get nearby objects from partner database. If we get a
-                    #                named object, don't bother choosing a counter. Just use
-                    #                the old name to avoid confusion.
-                    xmresults = getNearbyObjectsFromAlternateDatabase(dbName, ALTERNATE_DB_CONNECTIONS, transient, coneSearchRadius)
+                # 2017-10-04 KWS Get nearby objects from partner database. If we get a
+                #                named object, don't bother choosing a counter. Just use
+                #                the old name to avoid confusion.
+                xmresults = getNearbyObjectsFromAlternateDatabase(dbName, ALTERNATE_DB_CONNECTIONS, transient, coneSearchRadius)
 
-                    # Override the listId with the value from the form if it exists
+                # Override the listId with the value from the form if it exists
 
-                    listId = PROMOTE_DEMOTE[value]
-                    if listId < 0:
-                        listId = originallistId
+                listId = PROMOTE_DEMOTE[value]
+                if listId < 0:
+                    listId = originallistId
 
-                    atlasDesignation = transient.atlas_designation
-                    surveyField = transient.survey_field
-                    fieldCounter = transient.followup_counter
+                atlasDesignation = transient.atlas_designation
+                surveyField = transient.survey_field
+                fieldCounter = transient.followup_counter
 
 
-                    if not atlasDesignation and (listId == GOOD or listId == ATTIC or listId == FOLLOWUP):
-                        # ASSUMPTION!!  All filenames contain dots and the first part is the field name.
-                        surveyField = 'ATLAS'
+                if not atlasDesignation and (listId == GOOD or listId == ATTIC or listId == FOLLOWUP):
+                    # ASSUMPTION!!  All filenames contain dots and the first part is the field name.
+                    surveyField = 'ATLAS'
 
-                        try:
-                           fieldCode = SURVEY_FIELDS[surveyField]
-                        except KeyError:
-                           # Can't find the field, so record the code as 'XX'
-                           fieldCode = 'ATLAS'
+                    try:
+                        fieldCode = SURVEY_FIELDS[surveyField]
+                    except KeyError:
+                        # Can't find the field, so record the code as 'XX'
+                        fieldCode = 'ATLAS'
 
-                        # Let's assume that there's no field counters table.  Let's try and calculate
-                        # what the number should be from the data.
+                    # Let's assume that there's no field counters table.  Let's try and calculate
+                    # what the number should be from the data.
 
-                        followupFlagDate = transient.followup_flag_date
-                        if followupFlagDate is None:
-                           followupFlagDate = datetime.date.today()
-                           objectFlagMonth = datetime.date.today().month
-                           objectFlagYear = datetime.date.today().year
-                        else:
-                           objectFlagMonth = followupFlagDate.month
-                           objectFlagYear = followupFlagDate.year
+                    followupFlagDate = transient.followup_flag_date
+                    if followupFlagDate is None:
+                        followupFlagDate = datetime.date.today()
+                        objectFlagMonth = datetime.date.today().month
+                        objectFlagYear = datetime.date.today().year
+                    else:
+                        objectFlagMonth = followupFlagDate.month
+                        objectFlagYear = followupFlagDate.year
 
-                        if xmresults['xmNearestName']:
-                            fieldCounter = xmresults['xmNearestCounter']
-                            atlasDesignation = xmresults['xmNearestName']
-                        else:
+                    if xmresults['xmNearestName']:
+                        fieldCounter = xmresults['xmNearestCounter']
+                        atlasDesignation = xmresults['xmNearestName']
+                    else:
 #                            fieldCounter = AtlasDiffObjects.objects.filter(followup_flag_date__year = objectFlagYear, survey_field = surveyField, atlas_designation__contains=(objectFlagYear-2000)).aggregate(Max('followup_counter'))['followup_counter__max']
 #                            if fieldCounter is None:
 #                               # This is the first time we've used the counter
@@ -3307,49 +3360,49 @@ def followupQuickView(request, listNumber):
 #
 #                            atlasDesignation = '%s%d%s' % (fieldCode, objectFlagYear - 2000, base26(fieldCounter))
 
-                            nameData = getLocalObjectName(settings.NAMESERVER_API_URL, settings.NAMESERVER_TOKEN, transient.id, transient.ra, transient.dec, followupFlagDate.strftime("%Y-%m-%d"), dbName)
-                            if nameData:
-                                if nameData['status'] == 201 and nameData['counter'] is not None and nameData['name'] is not None:
-                                    sys.stderr.write("\n%s\n" % nameData['info'])
-                                    fieldCounter = nameData['counter']
-                                    atlasDesignation = nameData['name']
-                                else:
-                                    sys.stderr.write("\nStatus = %s. %s\n" % (str(nameData['status']), nameData['info']))
-                                    request.session['error'] = "ERROR: Nameserver error. Status = %s. %s" % (str(nameData['status']), nameData['info'])
-                                    redirect_to = "../../error/"
-                                    return HttpResponseRedirect(redirect_to)
+                        nameData = getLocalObjectName(settings.NAMESERVER_API_URL, settings.NAMESERVER_TOKEN, transient.id, transient.ra, transient.dec, followupFlagDate.strftime("%Y-%m-%d"), dbName)
+                        if nameData:
+                            if nameData['status'] == 201 and nameData['counter'] is not None and nameData['name'] is not None:
+                                sys.stderr.write("\n%s\n" % nameData['info'])
+                                fieldCounter = nameData['counter']
+                                atlasDesignation = nameData['name']
                             else:
-                                sys.stderr.write("\nBad response from the nameserver. Something went wrong.\n")
-                                request.session['error'] = "ERROR: Bad response from the Nameserver."
+                                sys.stderr.write("\nStatus = %s. %s\n" % (str(nameData['status']), nameData['info']))
+                                request.session['error'] = "ERROR: Nameserver error. Status = %s. %s" % (str(nameData['status']), nameData['info'])
                                 redirect_to = "../../error/"
                                 return HttpResponseRedirect(redirect_to)
-                    try:
-                        # 2011-02-24 KWS Added Observation Status
-                        # 2013-10-29 KWS Added date_modified so we can track when bulk updates were done.
-                        # 2017-10-17 KWS Who modified the objects?
-                        processingStatusData = TcsProcessingStatus.objects.all().exclude(status = 2)
-                        if len(processingStatusData) == 1:
-                            processingStatus = processingStatusData[0].status
-                            processingStartTime = processingStatusData[0].started
-                            if processingStatus == 1:
-                                request.session['error'] = "WARNING: Database is busy doing a backup. Please come back later."
-                                redirect_to = "../../error/"
-                                return HttpResponseRedirect(redirect_to)  
-                        AtlasDiffObjects.objects.filter(pk=int(key.replace('_promote_demote', ''))).update(detection_list_id = listId,
-                                                                                                                   survey_field = surveyField,
-                                                                                                               followup_counter = fieldCounter,
-                                                                                                              atlas_designation = atlasDesignation,
-                                                                                                                     updated_by = request.user.username, 
-                                                                                                                  date_modified = datetime.datetime.now()) 
-                    except IntegrityError as e:
-                        if e[0] == 1062: # Duplicate Key error
-                            pass # Do nothing - will eventually raise some errors on the form
+                        else:
+                            sys.stderr.write("\nBad response from the nameserver. Something went wrong.\n")
+                            request.session['error'] = "ERROR: Bad response from the Nameserver."
+                            redirect_to = "../../error/"
+                            return HttpResponseRedirect(redirect_to)
+                try:
+                    # 2011-02-24 KWS Added Observation Status
+                    # 2013-10-29 KWS Added date_modified so we can track when bulk updates were done.
+                    # 2017-10-17 KWS Who modified the objects?
+                    processingStatusData = TcsProcessingStatus.objects.all().exclude(status = 2)
+                    if len(processingStatusData) == 1:
+                        processingStatus = processingStatusData[0].status
+                        processingStartTime = processingStatusData[0].started
+                        if processingStatus == 1:
+                            request.session['error'] = "WARNING: Database is busy doing a backup. Please come back later."
+                            redirect_to = "../../error/"
+                            return HttpResponseRedirect(redirect_to)  
+                    AtlasDiffObjects.objects.filter(pk=int(key.replace('_promote_demote', ''))).update(detection_list_id = listId,
+                                                                                                                survey_field = surveyField,
+                                                                                                            followup_counter = fieldCounter,
+                                                                                                            atlas_designation = atlasDesignation,
+                                                                                                                    updated_by = request.user.username, 
+                                                                                                                date_modified = datetime.datetime.now()) 
+                except IntegrityError as e:
+                    if e[0] == 1062: # Duplicate Key error
+                        pass # Do nothing - will eventually raise some errors on the form
 
-                    if settings.VRA_ADD_ROW:
-                        originalListId = transient.detection_list_id.id
-                        addVraRow(transient.id, originalListId, listId, request.user.username, settings)
+                if settings.VRA_ADD_ROW:
+                    originalListId = transient.detection_list_id.id
+                    addVraRow(transient.id, originalListId, listId, request.user.username, settings)
 
-
+    # Otherwise handle for a get request
     else:
         if objectName:
             formSearchObject = SearchForObjectForm(initial={'searchText': objectName})
@@ -3389,8 +3442,22 @@ def followupQuickView(request, listNumber):
         table = AtlasDiffObjectsTablePublic(objectsQueryset, order_by=request.GET.get('sort', '-followup_id'))
 
     RequestConfig(request, paginate={"per_page": nobjects}).configure(table)
+    
+    context = {
+        'table': table, 
+        'rows': table.rows, 
+        'listHeader': listHeader, 
+        'form_searchobject': formSearchObject, 
+        'dbname': dbName, 
+        'list_id': list_id, 
+        'public': public, 
+        'fgss': fgss, 
+        'processingStatus': processingStatus, 
+        'nobjects': nobjects,
+        'can_edit_fl': can_edit_fl,
+    }
 
-    return render(request, 'atlas/followup_quickview_bs.html', {'table': table, 'rows': table.rows, 'listHeader': listHeader, 'form_searchobject': formSearchObject, 'dbname': dbName, 'list_id': list_id, 'public': public, 'fgss': fgss, 'processingStatus': processingStatus, 'nobjects': nobjects})
+    return render(request, 'atlas/followup_quickview_bs.html', context)
 
 
 # 2013-12-12 KWS Added followupQuickViewAll mainly for the public pages.
@@ -3450,9 +3517,20 @@ def followupAllQuickView(request):
         nobjects = 100
 
     RequestConfig(request, paginate={"per_page": nobjects}).configure(table)
+    
+    context = {
+        'table': table, 
+        'rows': table.rows, 
+        'listHeader': listHeader, 
+        'form_searchobject': formSearchObject, 
+        'dbname': dbName, 
+        'public': public, 
+        'fgss': fgss, 
+        'nobjects': nobjects,
+    }
 
-    return render(request, 'atlas/followup_quickview_bs.html', {'table': table, 'rows': table.rows, 'listHeader': listHeader, 'form_searchobject': formSearchObject, 'dbname': dbName, 'public': public, 'fgss': fgss, 'nobjects': nobjects})
 
+    return render(request, 'atlas/followup_quickview_bs.html', context)
 
 @login_required
 def followupAllPublicQuickView(request):
@@ -3506,8 +3584,19 @@ def followupAllPublicQuickView(request):
         nobjects = 100
 
     RequestConfig(request, paginate={"per_page": nobjects}).configure(table)
+    
+    context = {
+        'table': table, 
+        'rows': table.rows, 
+        'listHeader': listHeader, 
+        'form_searchobject': formSearchObject, 
+        'dbname': dbName, 
+        'public': public, 
+        'fgss': fgss, 
+        'nobjects': nobjects
+    }
 
-    return render(request, 'atlas/followup_quickview_bs.html', {'table': table, 'rows': table.rows, 'listHeader': listHeader, 'form_searchobject': formSearchObject, 'dbname': dbName, 'public': public, 'fgss': fgss, 'nobjects': nobjects})
+    return render(request, 'atlas/followup_quickview_bs.html', context)
 
 
 # 2015-03-06 KWS Added new quickview custom lists
@@ -3567,8 +3656,19 @@ def userDefinedListsQuickview(request, userDefinedListNumber):
         nobjects = 100
 
     RequestConfig(request, paginate={"per_page": nobjects}).configure(table)
+    
+    context = {
+        'table': table, 
+        'rows': table.rows, 
+        'listHeader': listHeader, 
+        'form_searchobject': formSearchObject, 
+        'dbname': dbName, 
+        'public': public, 
+        'fgss': fgss, 
+        'nobjects': nobjects
+    }
 
-    return render(request, 'atlas/followup_quickview_bs.html', {'table': table, 'rows': table.rows, 'listHeader': listHeader, 'form_searchobject': formSearchObject, 'dbname': dbName, 'public': public, 'fgss': fgss, 'nobjects': nobjects})
+    return render(request, 'atlas/followup_quickview_bs.html', context)
 
 
 @login_required
@@ -3707,8 +3807,18 @@ def searchResults(request):
             sc = SherlockClassifications.objects.filter(transient_object_id_id = row.id)
             row.sc = sc
 
+    context = {
+        'subdata': subdata, 
+        'connection': connection, 
+        'form_searchobject' : form, 
+        'dbname': dbName, 
+        'public': public, 
+        'searchText': searchText, 
+        'nobjects': nobjects, 
+        'showObjectLCThreshold': SHOW_LC_DATA_LIMIT
+    }
 
-    return render(request, 'atlas/search_results_plotly.html', {'subdata': subdata, 'connection': connection, 'form_searchobject' : form, 'dbname': dbName, 'public': public, 'searchText': searchText, 'nobjects': nobjects, 'showObjectLCThreshold': SHOW_LC_DATA_LIMIT})
+    return render(request, 'atlas/search_results_plotly.html', context)
 
 
 # 2018-07-02 KWS New version of the quickview pages, using plotly and bootstrap.
@@ -3805,7 +3915,8 @@ def followupQuickViewBootstrapPlotly(request, listNumber):
         except FieldDoesNotExist as e:
             sort = ['-rank']
             break
-
+    can_edit_fl = has_write_permissions(request.user)
+    
     # 2015-11-17 KWS Get the processing status. If it's not 2, what is it?
     processingStatusData = TcsProcessingStatus.objects.all().exclude(status = 2)
     processingStatus = None
@@ -3814,6 +3925,11 @@ def followupQuickViewBootstrapPlotly(request, listNumber):
         processingStatus = processingStatusData[0].status
         processingStartTime = processingStatusData[0].started
 
+    # If the processing status is 1, we can't edit the observations
+    if processingStatus == 1:
+        can_edit_fl = False
+    logger.debug("User can edit observations: %s" % can_edit_fl)
+    
     objectName = None
 
     # Dummy form search object
@@ -3845,7 +3961,7 @@ def followupQuickViewBootstrapPlotly(request, listNumber):
                             objectsQueryset.append(obj)
                 else:
                     objectsQueryset = WebViewFollowupTransientsGeneric.objects.filter(**queryFilter).order_by(*sort)
-        else:
+        elif can_edit_fl:
             # We're using the submit form for the object updates
             #objectsQueryset = AtlasDiffObjects.objects.filter(**queryFilter)
             if queryFilterGW:
@@ -4035,5 +4151,21 @@ def followupQuickViewBootstrapPlotly(request, listNumber):
             sc = SherlockClassifications.objects.filter(transient_object_id_id = row.id)
             row.sc = sc
 
-    return render(request, 'atlas/search_results_plotly.html', {'subdata': subdata, 'listHeader': listHeader, 'form_searchobject' : formSearchObject, 'dbname': dbName, 'list_id': list_id, 'processingStatus': processingStatus, 'nobjects': nobjects, 'public': public, 'searchText': searchText, 'urlsuffix': urlsuffix, 'classifyform': True, 'showObjectLCThreshold': SHOW_LC_DATA_LIMIT })
+    context = {
+        'subdata': subdata, 
+        'listHeader': listHeader, 
+        'form_searchobject' : formSearchObject, 
+        'dbname': dbName, 
+        'list_id': list_id, 
+        'processingStatus': processingStatus, 
+        'nobjects': nobjects, 
+        'public': public, 
+        'searchText': searchText, 
+        'urlsuffix': urlsuffix, 
+        'classifyform': True, 
+        'showObjectLCThreshold': SHOW_LC_DATA_LIMIT,
+        "can_edit_fl": can_edit_fl,
+    }
+
+    return render(request, 'atlas/search_results_plotly.html', context)
 

--- a/psat_server_web/atlas/atlasapi/authentication.py
+++ b/psat_server_web/atlas/atlasapi/authentication.py
@@ -34,9 +34,10 @@ class ExpiringTokenAuthentication(TokenAuthentication):
             # Otherwise use the default expiration time
             token_expiration_time = settings.TOKEN_EXPIRY
         
-        # Calculate the token's age and compare it to the expiration setting
+        # If we're not dealing with a staff member, calculate the token's age 
+        # and compare it to the expiration setting
         token_age = (now() - token.created).total_seconds()
-        if token_age > token_expiration_time:
+        if not user.is_staff and token_age > token_expiration_time:
             logger.warning(f'User {user} attempted to use an expired token.')
             raise AuthenticationFailed('Token has expired.')
         

--- a/psat_server_web/atlas/atlasapi/throttling.py
+++ b/psat_server_web/atlas/atlasapi/throttling.py
@@ -1,0 +1,16 @@
+from rest_framework.throttling import UserRateThrottle
+
+   
+class UserAdminRateThrottle(UserRateThrottle):
+    
+    def get_rate(self):
+        # Check if a user is authenticated and is an admin.
+        if self.request and hasattr(self.request, 'user') and self.request.user.is_staff:
+            # Use the admin scope.
+            self.scope = 'admin'
+        else:
+            # Use the user scope.
+            self.scope = 'user'
+        
+        # For either case, return the rate the usual way.
+        return super().get_rate()

--- a/psat_server_web/atlas/atlasapi/throttling.py
+++ b/psat_server_web/atlas/atlasapi/throttling.py
@@ -1,10 +1,10 @@
-from rest_framework.throttling import UserRateThrottle, ScopedRateThrottle
+from rest_framework.throttling import UserRateThrottle
    
 class UserAdminRateThrottle(UserRateThrottle):
     
     def get_rate(self, request=None):
         # Check if a user is authenticated and is an admin.
-        if request and hasattr(request, 'user') and request.user.is_staff:
+        if request and hasattr(request, 'user') and (request.user.is_staff or request.user.is_superuser):
             # Use the admin scope.
             self.scope = 'admin'
         else:
@@ -21,6 +21,3 @@ class UserAdminRateThrottle(UserRateThrottle):
         self.num_requests, self.duration = self.parse_rate(self.rate)
 
         return super().allow_request(request, view)
-
-class BurstRateThrottle(ScopedRateThrottle):
-    scope = 'burst'

--- a/psat_server_web/atlas/atlasapi/views.py
+++ b/psat_server_web/atlas/atlasapi/views.py
@@ -70,7 +70,6 @@ class ObtainExpiringAuthToken(ObtainAuthToken):
 class ConeView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasReadAccess]
-    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = ConeSerializer(data=request.GET, context={'request': request})
@@ -90,7 +89,6 @@ class ConeView(APIView):
 class ObjectsView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasReadAccess]
-    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = ObjectsSerializer(data=request.GET, context={'request': request})
@@ -110,7 +108,6 @@ class ObjectsView(APIView):
 class ObjectListView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasReadAccess]
-    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = ObjectListSerializer(data=request.GET, context={'request': request})
@@ -130,7 +127,6 @@ class ObjectListView(APIView):
 class VRAScoresView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasWriteAccess]
-    throttle_scope = 'burst'
 
     def get(self, request):
         return Response({"Error": "GET is not implemented for this service."})
@@ -148,7 +144,6 @@ class VRAScoresView(APIView):
 class VRAScoresListView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasReadAccess]
-    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = VRAScoresListSerializer(data=request.GET, context={'request': request})
@@ -169,7 +164,6 @@ class VRAScoresListView(APIView):
 class VRATodoView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasWriteAccess]
-    throttle_scope = 'burst'
 
     def get(self, request):
         return Response({"Error": "GET is not implemented for this service."})
@@ -187,7 +181,6 @@ class VRATodoView(APIView):
 class VRATodoListView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasReadAccess]
-    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = VRATodoListSerializer(data=request.GET, context={'request': request})
@@ -206,7 +199,6 @@ class VRATodoListView(APIView):
 class TcsObjectGroupsView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasWriteAccess]
-    throttle_scope = 'burst'
 
     def get(self, request):
         return Response({"Error": "GET is not implemented for this service."})
@@ -223,7 +215,6 @@ class TcsObjectGroupsView(APIView):
 class TcsObjectGroupsListView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasReadAccess]
-    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = TcsObjectGroupsListSerializer(data=request.GET, context={'request': request})
@@ -244,7 +235,6 @@ class TcsObjectGroupsDeleteView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     # TODO: Change this to HasDeleteAccess?
     permission_classes = [IsAuthenticated&HasWriteAccess]
-    throttle_scope = 'burst'
 
     def get(self, request):
         return Response({"Error": "GET is not implemented for this service."})
@@ -268,7 +258,6 @@ class TcsObjectGroupsDeleteView(APIView):
 class VRARankView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasWriteAccess]
-    throttle_scope = 'burst'
 
     def get(self, request):
         return Response({"Error": "GET is not implemented for this service."})
@@ -286,7 +275,6 @@ class VRARankView(APIView):
 class VRARankListView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasReadAccess]
-    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = VRARankListSerializer(data=request.GET, context={'request': request})
@@ -327,7 +315,6 @@ class ExternalCrossmatchesListView(APIView):
 class ObjectDetectionListView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasWriteAccess]
-    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = ObjectDetectionListSerializer(data=request.GET, context={'request': request})

--- a/psat_server_web/atlas/atlasapi/views.py
+++ b/psat_server_web/atlas/atlasapi/views.py
@@ -7,7 +7,7 @@ from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.authtoken.views import ObtainAuthToken
-from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.throttling import AnonRateThrottle
 
 # 2024-01-29 KWS Need the model to do inserts.
 from atlas.models import TcsObjectGroups, TcsVraScores
@@ -35,6 +35,7 @@ def retcode(message):
     else:                  return status.HTTP_200_OK
     
 class ObtainExpiringAuthToken(ObtainAuthToken):
+    throttle_classes = [AnonRateThrottle]
    
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data, context={'request': request})
@@ -69,6 +70,7 @@ class ObtainExpiringAuthToken(ObtainAuthToken):
 class ConeView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasReadAccess]
+    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = ConeSerializer(data=request.GET, context={'request': request})
@@ -88,6 +90,7 @@ class ConeView(APIView):
 class ObjectsView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasReadAccess]
+    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = ObjectsSerializer(data=request.GET, context={'request': request})
@@ -107,6 +110,7 @@ class ObjectsView(APIView):
 class ObjectListView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasReadAccess]
+    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = ObjectListSerializer(data=request.GET, context={'request': request})
@@ -126,6 +130,7 @@ class ObjectListView(APIView):
 class VRAScoresView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasWriteAccess]
+    throttle_scope = 'burst'
 
     def get(self, request):
         return Response({"Error": "GET is not implemented for this service."})
@@ -143,6 +148,7 @@ class VRAScoresView(APIView):
 class VRAScoresListView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasReadAccess]
+    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = VRAScoresListSerializer(data=request.GET, context={'request': request})
@@ -163,6 +169,7 @@ class VRAScoresListView(APIView):
 class VRATodoView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasWriteAccess]
+    throttle_scope = 'burst'
 
     def get(self, request):
         return Response({"Error": "GET is not implemented for this service."})
@@ -180,6 +187,7 @@ class VRATodoView(APIView):
 class VRATodoListView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasReadAccess]
+    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = VRATodoListSerializer(data=request.GET, context={'request': request})
@@ -198,6 +206,7 @@ class VRATodoListView(APIView):
 class TcsObjectGroupsView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasWriteAccess]
+    throttle_scope = 'burst'
 
     def get(self, request):
         return Response({"Error": "GET is not implemented for this service."})
@@ -214,6 +223,7 @@ class TcsObjectGroupsView(APIView):
 class TcsObjectGroupsListView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasReadAccess]
+    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = TcsObjectGroupsListSerializer(data=request.GET, context={'request': request})
@@ -234,6 +244,7 @@ class TcsObjectGroupsDeleteView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     # TODO: Change this to HasDeleteAccess?
     permission_classes = [IsAuthenticated&HasWriteAccess]
+    throttle_scope = 'burst'
 
     def get(self, request):
         return Response({"Error": "GET is not implemented for this service."})
@@ -257,6 +268,7 @@ class TcsObjectGroupsDeleteView(APIView):
 class VRARankView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasWriteAccess]
+    throttle_scope = 'burst'
 
     def get(self, request):
         return Response({"Error": "GET is not implemented for this service."})
@@ -274,6 +286,7 @@ class VRARankView(APIView):
 class VRARankListView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasReadAccess]
+    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = VRARankListSerializer(data=request.GET, context={'request': request})
@@ -314,6 +327,7 @@ class ExternalCrossmatchesListView(APIView):
 class ObjectDetectionListView(APIView):
     authentication_classes = [ExpiringTokenAuthentication, QueryAuthentication]
     permission_classes = [IsAuthenticated&HasWriteAccess]
+    throttle_scope = 'burst'
 
     def get(self, request):
         serializer = ObjectDetectionListSerializer(data=request.GET, context={'request': request})

--- a/psat_server_web/atlas/templates/atlas/candidate.html
+++ b/psat_server_web/atlas/templates/atlas/candidate.html
@@ -877,50 +877,55 @@ new SkyWindow2(options).attach($('#mySkyWnd')[0]);
 
 <!-- 2011-04-04 KWS Added the User Defined Lists -->
 {% if not public and user.is_authenticated %}
-{% if processingStatus != 1 %}
+  {% if processingStatus != 1 %}
 
-{% if userList %}
-<div id="userdefinedlists">
-<table class="generictable">
-   <tr>
-      <th>Object is a member of:</th>
-   </tr>
-   {% for row in userList %}
-   <tr>
-      <td><a href="../../userlist/{{row.object_group_id.id}}/">{{ row.object_group_id.description }}</a></td>
-   </tr>
-   {% endfor %}
-</table>
-</div>
-{% endif %}
+    {% if userList %}
+      <div id="userdefinedlists">
+      <table class="generictable">
+      <tr>
+          <th>Object is a member of:</th>
+      </tr>
+      {% for row in userList %}
+        <tr>
+            <td><a href="../../userlist/{{row.object_group_id.id}}/">{{ row.object_group_id.description }}</a></td>
+        </tr>
+      {% endfor %}
+    </table>
+    </div>
+    {% endif %}
 
 
-<div id="classifyobjectform">
+    <div id="classifyobjectform">
 
-<!-- 2011-10-04 KWS Removed the ifnotequal for list = 0 - i.e. allow form for Garbage objects now -->
+    <!-- 2011-10-04 KWS Removed the ifnotequal for list = 0 - i.e. allow form for Garbage objects now -->
 
-{% if transient.detection_list_id.id >= 0 %}
-   {% if form %}
-   {% if form.errors %}
-       <p style="color: red;">
-           Please correct the error{{ form.errors|pluralize }} below.
-       </p>
-   {% endif %}
+    {% if transient.detection_list_id.id >= 0 %}
+      {% if form %}
+        {% if form.errors %}
+            <p style="color: red;">
+                Please correct the error{{ form.errors|pluralize }} below.
+            </p>
+        {% endif %}
 
-   <form action="" method="post" id="classifyform">{% csrf_token %}
-   <table class="forms">
-       {{ form.as_table }}
-   </table>
-   <input type="submit" value="Update Object" />
-   </form>
-   {% endif %}
-{% endif %}
+        <form action="" method="post" id="classifyform">{% csrf_token %}
+        <table class="forms">
+            {{ form.as_table }}
+        </table>
+        {% if can_edit_fl == 1 %}
+          <input type="submit" value="Update Object" />
+        {% else %}
+          <input type="submit" value="Update Object" disabled />
+          {% include "atlas/permissions_alert.html" %}
+        {% endif %}
+        </form>
+      {% endif %}
+    {% endif %}
 
-</div>
+    </div>
 
-{% else %}
-Database Dump in Progress. Updates not allowed.
-{% endif %}
+  {% else %}
+    Database Dump in Progress. Updates not allowed.
+  {% endif %}
 {% endif %}
 
 

--- a/psat_server_web/atlas/templates/atlas/candidate_plotly.html
+++ b/psat_server_web/atlas/templates/atlas/candidate_plotly.html
@@ -899,40 +899,45 @@ jscolourlabelsglobal["#flot-colourplot-forced"] = jscolourlabelsforced;
         </div>
         {% endfor %}
         {% for field in form.visible_fields %}
-        <div class="form-group has-errors text-danger small">
-            {{ field.errors }}
-        </div>
-        <div class="form-group">
-            {{ field.label }}
-        </div>
-        <div class="form-group">
-        {% if field.name == "promote_demote" %}
-          <div class="btn-group flex-wrap btn-group-toggle" data-toggle="buttons">
-          {% for radio in field %}
-            <label for="{{ radio.id_for_label }}" class="btn btn-outline-secondary btn-sm {% if forloop.last %}active{% endif %}">{{ radio.choice_label }}
-            {{ radio.tag }}
-            </label>
-          {% endfor %}
+          <div class="form-group has-errors text-danger small">
+              {{ field.errors }}
           </div>
-        {% elif field.name == "user_list_membership" %}
-          {% for choice in field %}
-          <div class="checkbox">
-            {{ choice.tag }}
-            <label for="{{ choice.id_for_label }}">{{ choice.choice_label }}<br />
-            </label>
+          <div class="form-group">
+              {{ field.label }}
           </div>
-          {% endfor %}
+          <div class="form-group">
+          {% if field.name == "promote_demote" %}
+            <div class="btn-group flex-wrap btn-group-toggle" data-toggle="buttons">
+            {% for radio in field %}
+              <label for="{{ radio.id_for_label }}" class="btn btn-outline-secondary btn-sm {% if forloop.last %}active{% endif %}">{{ radio.choice_label }}
+              {{ radio.tag }}
+              </label>
+            {% endfor %}
+          </div>
+          {% elif field.name == "user_list_membership" %}
+            {% for choice in field %}
+              <div class="checkbox">
+                {{ choice.tag }}
+                <label for="{{ choice.id_for_label }}">{{ choice.choice_label }}<br />
+                </label>
+              </div>
+            {% endfor %}
 
-        {% else %}
+          {% else %}
             {{ field }}
-        {% endif %}
+          {% endif %}
         </div>
         {% endfor %}
 
         {% for hidden in form.hidden_fields %}
           {{ hidden }}
         {% endfor %}
-        <button class="btn btn-outline-info my-2 my-sm-0" type="submit" value="Update Object">Update Object</button>
+        {% if can_edit_fl == 1 %}
+          <button class="btn btn-outline-info my-2 my-sm-0" type="submit" value="Update Object">Update Object</button>
+        {% else %}
+          <button class="btn btn-outline-secondary my-2 my-sm-0" type="submit" value="Update Object" disabled>Update Object</button>
+          {% include "atlas/permissions_alert.html" %}
+        {% endif %}
     </form>
   </div>
   {% endif %}

--- a/psat_server_web/atlas/templates/atlas/followup_quickview.html
+++ b/psat_server_web/atlas/templates/atlas/followup_quickview.html
@@ -369,14 +369,19 @@
 </table>
 
 {% if not public %}
-{% if processingStatus != 1 %}
-{% if listHeader %}
-  {% if list_id >= 0 and list_id < 9 %}
-<input type="submit" value="Classify Objects" name="classify" /></p>
+  {% if processingStatus != 1 %}
+    {% if listHeader %}
+      {% if list_id >= 0 and list_id < 9 %}
+        {% if can_edit_fl == 1 %}
+          <input type="submit" value="Classify Objects" name="classify" /></p>
+        {% else %}
+          <input type="submit" value="Classify Objects" name="classify" disabled/></p>
+          {% include "atlas/permissions_alert.html" %}
+        {% endif %}
+      {% endif %}
+    </form>
+    {% endif %}
   {% endif %}
-</form>
-{% endif %}
-{% endif %}
 {% endif %}
 
 <script language="javascript" type="text/javascript" src="{{ STATIC_URL }}js/flot/jquery-1.7.2.js"></script>

--- a/psat_server_web/atlas/templates/atlas/followup_quickview_bs.html
+++ b/psat_server_web/atlas/templates/atlas/followup_quickview_bs.html
@@ -33,7 +33,12 @@
 
 {% if listHeader %}
   {% if list_id >= 0 and list_id <= 10 and table.rows|length > 0 %}
-<input type="submit" value="Classify Objects" name="classify" /></p>
+    {% if can_edit_fl == 1 %}
+      <input type="submit" value="Classify Objects" name="classify" /></p>
+    {% else %}
+      <input type="submit" value="Classify Objects" name="classify" disabled /></p>
+      {% include "atlas/permissions_alert.html" %}
+    {% endif %}
   {% endif %}
 </form>
 {% endif %}

--- a/psat_server_web/atlas/templates/atlas/permissions_alert.html
+++ b/psat_server_web/atlas/templates/atlas/permissions_alert.html
@@ -1,0 +1,4 @@
+<div class="alert alert-secondary" role="alert">
+    You do not have permissions to classify objects.
+    Please contact your administrator if you think this is an error.
+</div>

--- a/psat_server_web/atlas/templates/atlas/search_results_plotly.html
+++ b/psat_server_web/atlas/templates/atlas/search_results_plotly.html
@@ -126,7 +126,12 @@ jslimitsglobal["#flot-lightcurve{{row.id}}"] = jslclimits;
 {% if processingStatus != 1 %}
   {% if classifyform and subdata.paginator.count %}
   <form id="classify_form" action="" method="post">{% csrf_token %}
-  <button class="btn btn-outline-info my-2 my-sm-0" type="submit" value="Classify Objects" name="classify">Classify</button>
+    {% if can_edit_fl == 1 %}
+      <button class="btn btn-outline-info my-2 my-sm-0" type="submit" value="Classify Objects" name="classify">Classify</button>
+    {% else %}
+      <button class="btn btn-outline-secondary my-2 my-sm-0" type="submit" value="Classify Objects" name="classify" disabled>Classify</button>
+      {% include "atlas/permissions_alert.html" %}
+    {% endif %}
   {% endif %}
 {% endif %}
 
@@ -492,7 +497,12 @@ jslimitsglobal["#flot-lightcurve{{row.id}}"] = jslclimits;
 
 {% if processingStatus != 1 %}
   {% if classifyform and subdata.paginator.count %}
-  <button class="btn btn-outline-info my-2 my-sm-0" type="submit" value="Classify Objects" name="classify">Classify</button>
+    {% if can_edit_fl == 1 %}
+      <button class="btn btn-outline-info my-2 my-sm-0" type="submit" value="Classify Objects" name="classify">Classify</button>
+    {% else %}
+      <button class="btn btn-outline-secondary my-2 my-sm-0" type="submit" value="Classify Objects" name="classify" disabled>Classify</button>
+      {% include "atlas/permissions_alert.html" %}
+    {% endif %}
   </form>
   {% endif %}
 {% endif %}

--- a/psat_server_web/atlas/tests/atlas/test_permissions.py
+++ b/psat_server_web/atlas/tests/atlas/test_permissions.py
@@ -1,0 +1,47 @@
+from django.contrib.auth.models import User, Permission, AnonymousUser
+from django.test import TestCase
+
+from atlas.permissions import has_write_permissions
+
+
+class HasWritePermissionsTest(TestCase):
+
+    def setUp(self):
+        # Create a regular user without permission.
+        self.user_without_perm = User.objects.create_user(
+            username="noperm",
+            password="password"
+        )
+        
+        # Create a user with the "has_write_access" permission.
+        self.user_with_perm = User.objects.create_user(
+            username="perm",
+            password="password"
+        )
+        permission = Permission.objects.get(codename='has_write_access')
+        self.user_with_perm.user_permissions.add(permission)
+        
+        # Create a staff user.
+        self.staff_user = User.objects.create_user(
+            username="staff",
+            password="password"
+        )
+        self.staff_user.is_staff = True
+        self.staff_user.save()
+
+    def test_unauthenticated_user(self):
+        # An anonymous user should not have write permissions.
+        anonymous = AnonymousUser()
+        self.assertFalse(has_write_permissions(anonymous))
+
+    def test_user_without_permission(self):
+        # A regular authenticated user without the permission should not have write permissions.
+        self.assertFalse(has_write_permissions(self.user_without_perm))
+
+    def test_user_with_permission(self):
+        # An authenticated user with the "has_write_access" permission should have write permissions.
+        self.assertTrue(has_write_permissions(self.user_with_perm))
+
+    def test_staff_user(self):
+        # A staff user should have write permissions regardless of explicit permission.
+        self.assertTrue(has_write_permissions(self.staff_user))

--- a/psat_server_web/atlas/tests/atlasapi/test_authentication.py
+++ b/psat_server_web/atlas/tests/atlasapi/test_authentication.py
@@ -116,7 +116,7 @@ class TokenAuthenticationStaffTests(TokenAuthenticationUserTests):
 
         # Make all created staff members staff
         self.no_group_user.is_staff = True
-        self.no_group_token.save()
+        self.no_group_user.save()
         self.no_profile_user.is_staff = True
         self.no_profile_user.save()
         self.week_user.is_staff = True
@@ -137,8 +137,10 @@ class TokenAuthenticationStaffTests(TokenAuthenticationUserTests):
         self.assertEqual(self.auth.authenticate_credentials(self.no_group_token.key), 
                          (self.no_group_user, self.no_group_token))
         
+        # Artificially backdate the token to simulate expiration
         self.no_group_token.created = now() - timedelta(days=settings.TOKEN_EXPIRY + 1)
         self.no_group_token.save()
+        
         # Staff members should not have their tokens expire
         self.assertEqual(self.auth.authenticate_credentials(self.no_group_token.key), 
                          (self.no_group_user, self.no_group_token))

--- a/psat_server_web/atlas/tests/atlasapi/test_permissions.py
+++ b/psat_server_web/atlas/tests/atlasapi/test_permissions.py
@@ -6,6 +6,7 @@ from rest_framework.test import APIClient
 from rest_framework.authtoken.models import Token
 
 from accounts.models import GroupProfile
+# from ..create_schema import AtlasTestCase
 
 class TestPermissionsSetup(TestCase):   
     def setUp(self) -> None:

--- a/psat_server_web/atlas/tests/atlasapi/test_throttling.py
+++ b/psat_server_web/atlas/tests/atlasapi/test_throttling.py
@@ -1,0 +1,66 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from rest_framework.test import APIRequestFactory
+
+from atlasapi.throttling import UserAdminRateThrottle
+
+dummy_rate_settings = {
+    'DEFAULT_THROTTLE_RATES': {
+        # For testing, use low limits.
+        'user': '3/min',         
+        'admin': '5/min',   
+    }
+}
+
+class TestUserAdminThrottle(TestCase):
+    def setUp(self):
+        # Clear the cache to ensure tests start fresh.
+        cache.clear()
+        self.factory = APIRequestFactory()
+        
+        # Create a regular user.
+        self.regular_user = User.objects.create_user(username='user', password='user')
+        
+        # Create an admin user.
+        self.admin_user = User.objects.create_user(username='admin', password='admin')
+        self.admin_user.is_staff = True
+        self.admin_user.save()
+        
+        # Set the throttle scope used by the view.
+        self.throttle_scope = 'admin'
+        
+        # A dummy view function for passing into allow_request.
+        self.view = lambda request: None
+
+    def test_regular_user_throttling(self):
+        throttle = UserAdminRateThrottle()
+        throttle.THROTTLE_RATES = dummy_rate_settings['DEFAULT_THROTTLE_RATES']
+        
+        request = self.factory.get('/dummy/')
+        request.user = self.regular_user
+
+        # Simulate three allowed requests.
+        for i in range(3):
+            allowed = throttle.allow_request(request, self.view)
+            self.assertTrue(allowed, f"Request {i+1} should be allowed for regular user")
+        
+        # The fourth request should be throttled.
+        allowed = throttle.allow_request(request, self.view)
+        self.assertFalse(allowed, "4th request should be throttled for regular user")
+        
+    def test_admin_user_throttling(self):
+        throttle = UserAdminRateThrottle()
+        throttle.THROTTLE_RATES = dummy_rate_settings['DEFAULT_THROTTLE_RATES']
+        
+        request = self.factory.get('/dummy/')
+        request.user = self.admin_user
+
+        # Simulate five allowed requests.
+        for i in range(5):
+            allowed = throttle.allow_request(request, self.view)
+            self.assertTrue(allowed, f"Admin request {i+1} should be allowed")
+        
+        # The sixth request should be throttled.
+        allowed = throttle.allow_request(request, self.view)
+        self.assertFalse(allowed, "6th request should be throttled for admin user")


### PR DESCRIPTION
Implements a simple version of rate throttling on the API calls and stops users from being able to update/classify candidates through the web interface. 

#### 1 Rate throttling
This is pretty straight forward and as discussed on slack previously. Essentially summed up in the default values in settings.py:

``` python
REST_FRAMEWORK = {
    'DEFAULT_THROTTLE_CLASSES': [
        'atlasapi.throttling.BurstRateThrottle',        # For authenticated users
        'atlasapi.throttling.UserAdminRateThrottle',    # Allow admin users unlimited rate, otherwise use the default rate 
    ],
    'DEFAULT_THROTTLE_RATES': {
        'anon': '10/hour',       # The only anonymous endpoint is the token refresh endpoint
        'user': '100/hour',      # Limit regular authenticated users to 100 requests per hour
        'admin': '100000/hour',  # Allow admin users (basically) unlimited rate
        'burst': '60/min',       # Also limit all authenticated users to 60 requests per minute
    }
```
where anonymous users are heavily limited and admin users are not (admin is considered a staff member, i.e. has the `is_staff` flag active. Burst applies to all but can be removed or altered to exclude staff members if needed. 

#### 2 Web permissions
Added a global permission `has_write_access` which denotes whether both of the following occur:
1. The submit buttons on the relevant web pages are active or not (and corresponding banner message saying why they are not active if relevant) 
2. Stops the processing of the POST response so no data is altered if a response is sent directly to the webserver (i.e. not from the web front end).

This should be enough to lock it down, assuming I haven't missed any other ways forms can be submitted to alter data! *Let me know thoughts etc.*

Outstanding:
- [ ] Rate throttling for cone search and item search
- [ ] Write permissions expiry time, will need to be global I think