### PR TITLE
feat: Django debug toolbar

### DIFF
--- a/psat_server_web/atlas/atlas/settings.py
+++ b/psat_server_web/atlas/atlas/settings.py
@@ -34,6 +34,10 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = None
 
 ALLOWED_HOSTS = ['*']
 
+INTERNAL_IPS = [
+    '127.0.0.1',
+]
+
 ROOT_URLCONF = 'atlas.urls'
 
 WSGI_APPLICATION = 'atlas.wsgi.application'
@@ -250,3 +254,17 @@ TOKEN_EXPIRY = int(os.environ.get("API_TOKEN_EXPIRY") or 86400) # seconds
 # Variables for the django_registration app
 ACCOUNT_ACTIVATION_DAYS = int(os.environ.get("ACCOUNT_ACTIVATION_DAYS") or 7)
 REGISTRATION_OPEN = True
+
+if DEBUG:
+    INSTALLED_APPS = [
+        *INSTALLED_APPS,
+        "debug_toolbar",
+    ]
+    MIDDLEWARE = [
+        "debug_toolbar.middleware.DebugToolbarMiddleware",
+        *MIDDLEWARE,
+    ]
+    DEBUG_TOOLBAR_CONFIG = {
+        # Always show the toolbar in debug mode
+        'SHOW_TOOLBAR_CALLBACK': lambda request: True,
+    }

--- a/psat_server_web/atlas/atlas/urls.py
+++ b/psat_server_web/atlas/atlas/urls.py
@@ -91,5 +91,10 @@ urlpatterns = [
 
 
 if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL,
-                          document_root=settings.MEDIA_ROOT)
+    urlpatterns.append(
+        path('__debug__/', include('debug_toolbar.urls'))
+    )
+    urlpatterns += static(
+        settings.MEDIA_URL,
+        document_root=settings.MEDIA_ROOT
+    )

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,11 @@ moduleDirectory = os.path.dirname(os.path.realpath(__file__))
 __version__ = ''
 exec(open(moduleDirectory + "/psat_server_web/__version__.py").read())
 
+
 def readme():
     with open(moduleDirectory + '/README.md') as f:
         return f.read()
+
 
 setup(
     name="psat-server-web",
@@ -44,6 +46,7 @@ setup(
           'requests',
           'lasair',
           'dustmaps',
+          'django-debug-toolbar',
       ],
     python_requires='>=3.6',
     include_package_data=True,


### PR DESCRIPTION
- [x] install toolbar
- [x] add middleware settings
- [x] add `__debug__` urls
- closes #36.

<img width="1546" height="879" alt="Screenshot of  a Django template view in Firefox, with the debug toolbar on the right." src="https://github.com/user-attachments/assets/a31ae00d-5fb1-4c61-bb2b-3f84cd6b79dd" />
