### PR TITLE
feat: give new users write permissions

### DIFF
--- a/psat_server_web/atlas/accounts/forms.py
+++ b/psat_server_web/atlas/accounts/forms.py
@@ -68,6 +68,13 @@ class CreateUserForm(forms.Form):
         )
     )
 
+    has_write_access = forms.BooleanField(
+        required=False,
+        label='Can edit observations',
+        widget=forms.CheckboxInput(),
+        help_text='Grant the user permission to edit observations.'
+    )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         for field_name, field in self.fields.items():

--- a/psat_server_web/atlas/accounts/views.py
+++ b/psat_server_web/atlas/accounts/views.py
@@ -3,7 +3,7 @@ from django.contrib.auth import views as auth_views
 from django.contrib import auth, messages
 from django import forms
 from django.contrib.auth.forms import UserCreationForm, PasswordChangeForm
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.contrib.auth.decorators import login_required, user_passes_test
 import logging
 
@@ -206,6 +206,15 @@ def create_user(request):
                 )
                 
                 user.save()
+
+                if form.cleaned_data.get('has_write_access'):
+                    # Grant write access if the checkbox is checked
+                    permission = Permission.objects.get(
+                        codename='has_write_access'
+                    )
+                    user.user_permissions.add(
+                        permission
+                    )
                 
                 # Add user to selected group
                 group = form.cleaned_data['group']

--- a/psat_server_web/atlas/templates/create_user.html
+++ b/psat_server_web/atlas/templates/create_user.html
@@ -81,6 +81,20 @@
                             </div>
                         </div>
 
+                        <div class="row">
+                            <div class="col-md-6">
+                                <div class="form-group">
+                                    {{ form.has_write_access }}
+                                    <label for="{{ form.has_write_access.id_for_label }}">Can edit observations</label>
+                                    {% if form.has_write_access.errors %}
+                                        <div id="{{ form.has_write_access.id_for_label }}_errorlist" class="text-danger">{{ form.has_write_access.errors }}</div>
+                                    {% endif %}
+                                    <small id="{{ form.has_write_access.id_for_label }}_helptext" class="form-text text-muted">
+                                        {{ form.has_write_access.help_text }}
+                                    </small>
+                                </div>
+                            </div>
+                        </div>
                         <div class="form-group">
                             <label for="{{ form.group.id_for_label }}">Group *</label>
                             {{ form.group }}


### PR DESCRIPTION
Add a new checkbox to the Create User form. If checked, add `accounts.has_write_access` permission to the new user account.

- towards #61.

<img width="767" height="790" alt="The Create User form. After the text inputs for account details, there's a new checkbox labelled 'Can edit observations'." src="https://github.com/user-attachments/assets/e405d9a5-c1d8-4fbb-b3fe-ebcfb9afa060" />
