### PR TITLE
fix: 'Create User' image uploads

### DIFF
--- a/psat_server_web/atlas/accounts/models.py
+++ b/psat_server_web/atlas/accounts/models.py
@@ -6,8 +6,20 @@ from django.db import models
 from django.core.validators import FileExtensionValidator
 from django.conf import settings
 import io
+import os
+import re
 
 from .utils import bytes2string
+
+
+def user_directory_path(instance, filename):
+    # file will be uploaded to MEDIA_ROOT/profile_pics/<username>/<filename>
+    # Securely extract the base filename and validate it
+    base_filename = os.path.basename(filename)
+    # Allow only alphanumerics, underscores, hyphens, and dots in filenames
+    if not re.fullmatch(r'[\w.\-]+', base_filename):
+        raise ValueError("Invalid profile image filename.")
+    return f'profile_pics/{instance.user.username}/{base_filename}'
 
 
 class UserProfile(models.Model):
@@ -32,8 +44,9 @@ class UserProfile(models.Model):
         default=False,
         help_text='If true, password requires changing before login'
     )
+
     image = models.ImageField(
-        upload_to='profile_pics/',
+        upload_to=user_directory_path,
         validators=[FileExtensionValidator(
             allowed_extensions=['gif', 'jpeg', 'jpg', 'png']
         )],

--- a/psat_server_web/atlas/accounts/views.py
+++ b/psat_server_web/atlas/accounts/views.py
@@ -193,7 +193,7 @@ def create_user(request):
     from django.contrib import messages
     
     if request.method == 'POST':
-        form = CreateUserForm(request.POST)
+        form = CreateUserForm(request.POST, request.FILES)
         if form.is_valid():
             try:
                 # Create the user
@@ -279,7 +279,9 @@ def change_profile_image(request):
     if request.method == 'POST':
         form = ChangeProfileImageForm(request.POST, request.FILES)
         if form.is_valid():
-            profile = UserProfile.objects.get(user=request.user)
+            profile, created = UserProfile.objects.get_or_create(
+                user=request.user
+            )
             image = form.cleaned_data.get('image')
             if image:
                 profile.image = image


### PR DESCRIPTION
- add `request.FILES` to `CreateUserForm`, so that image uploads work.
- add the account username to the media path for uploaded images.
- fix a bug where the app crashes if the user profile doesn't exist.
- towards #61.