### PR TITLE
Custom List Filtering like main Lists 

### DIFF
--- a/psat_server_web/atlas/atlas/apiutils.py
+++ b/psat_server_web/atlas/atlas/apiutils.py
@@ -234,11 +234,23 @@ def getVRATodoList(request, objects = [], dateThreshold = None, idThreshold = 0)
 
 
 # 2024-05-20 KWS Added getCustomListObjects
-def getCustomListObjects(request, objectid = None, objectgroupid = None):
+def getCustomListObjects(request, objectid = None, objectgroupid = None, queryFilter = None):
 
     customListObjects = []
 
-    if objectid is None and objectgroupid is not None:
+    if queryFilter:
+        # 2026-07-17 Claude wrote this for the objectgroupslist filtering task.
+        # tcs_object_groups has no vra/rb_pix/ra/dec/sherlock/spec_type columns, so
+        # resolve matching transient object ids via the enriched WebViewUserDefined
+        # view first, then filter tcs_object_groups by those ids.
+        filters = dict(queryFilter)
+        if objectgroupid is not None:
+            filters['object_group_id'] = objectgroupid
+        if objectid is not None:
+            filters['id'] = objectid
+        matchingIds = list(WebViewUserDefined.objects.filter(**filters).values_list('id', flat=True))
+        querySet = TcsObjectGroups.objects.filter(transient_object_id__id__in = matchingIds)
+    elif objectid is None and objectgroupid is not None:
         querySet = TcsObjectGroups.objects.filter(object_group_id = objectgroupid)
     elif objectid is not None and objectgroupid is None:
         querySet = TcsObjectGroups.objects.filter(transient_object_id__id = objectid)

--- a/psat_server_web/atlas/atlas/apiutils.py
+++ b/psat_server_web/atlas/atlas/apiutils.py
@@ -250,6 +250,8 @@ def getCustomListObjects(request, objectid = None, objectgroupid = None, queryFi
             filters['id'] = objectid
         matchingIds = list(WebViewUserDefined.objects.filter(**filters).values_list('id', flat=True))
         querySet = TcsObjectGroups.objects.filter(transient_object_id__id__in = matchingIds)
+        if objectgroupid is not None:
+            querySet = querySet.filter(object_group_id = objectgroupid)
     elif objectid is None and objectgroupid is not None:
         querySet = TcsObjectGroups.objects.filter(object_group_id = objectgroupid)
     elif objectid is not None and objectgroupid is None:

--- a/psat_server_web/atlas/atlas/apiutils.py
+++ b/psat_server_web/atlas/atlas/apiutils.py
@@ -254,8 +254,6 @@ def getCustomListObjects(request, objectid = None, objectgroupid = None, queryFi
         querySet = TcsObjectGroups.objects.filter(object_group_id = objectgroupid)
     elif objectid is not None and objectgroupid is None:
         querySet = TcsObjectGroups.objects.filter(transient_object_id__id = objectid)
-    else:
-        querySet = TcsObjectGroups.objects.all()
 
     if querySet is not None:
         for row in querySet:

--- a/psat_server_web/atlas/atlasapi/serializers.py
+++ b/psat_server_web/atlas/atlasapi/serializers.py
@@ -434,6 +434,16 @@ class TcsObjectGroupsDeleteSerializer(serializers.Serializer):
 class TcsObjectGroupsListSerializer(serializers.Serializer):
     objectid = serializers.IntegerField(required=False, default=None)
     objectgroupid = serializers.IntegerField(required=False, default=None)
+    vra_gte = serializers.FloatField(required=False, default=None)
+    vra_lte = serializers.FloatField(required=False, default=None)
+    rb_pix_gte = serializers.FloatField(required=False, default=None)
+    rb_pix_lte = serializers.FloatField(required=False, default=None)
+    ra_gte = serializers.FloatField(required=False, default=None)
+    ra_lte = serializers.FloatField(required=False, default=None)
+    dec_gte = serializers.FloatField(required=False, default=None)
+    dec_lte = serializers.FloatField(required=False, default=None)
+    sherlock_class = serializers.CharField(required=False, default=None)
+    spec_type = serializers.CharField(required=False, default=None)
 
     def save(self):
         objectid = self.validated_data['objectid']
@@ -441,7 +451,9 @@ class TcsObjectGroupsListSerializer(serializers.Serializer):
 
         request = self.context.get("request")
 
-        customListObjects = getCustomListObjects(request, objectid, objectGroupId)
+        queryFilter = buildObjectListQueryFilter(self.validated_data)
+
+        customListObjects = getCustomListObjects(request, objectid, objectGroupId, queryFilter = queryFilter)
         return customListObjects
 
 

--- a/psat_server_web/atlas/atlasapi/serializers.py
+++ b/psat_server_web/atlas/atlasapi/serializers.py
@@ -445,6 +445,11 @@ class TcsObjectGroupsListSerializer(serializers.Serializer):
     sherlock_class = serializers.CharField(required=False, default=None)
     spec_type = serializers.CharField(required=False, default=None)
 
+    def validate(self, data):
+        if data.get('objectid') is None and data.get('objectgroupid') is None:
+            raise serializers.ValidationError("Either objectid or objectgroupid must be provided.")
+        return data
+
     def save(self):
         objectid = self.validated_data['objectid']
         objectGroupId = self.validated_data['objectgroupid']

--- a/psat_server_web/atlas/test.py
+++ b/psat_server_web/atlas/test.py
@@ -1,0 +1,14 @@
+from atlasapiclient.client import RequestCustomListsTable
+
+OBJECTGROUPID = 73  # TODO Ken: replace with your real list id
+DEC_GTE = 10
+
+payload = {'objectgroupid': OBJECTGROUPID, 'dec_gte': DEC_GTE}
+
+client = RequestCustomListsTable(payload=payload, get_response=True)
+rows = client.response_data
+
+group_ids = sorted(set(row['object_group_id'] for row in rows))
+print("requested objectgroupid:", OBJECTGROUPID)
+print("distinct object_group_id in response:", group_ids)
+print("total rows:", len(rows))

--- a/psat_server_web/atlas/tests/atlasapi/test_object_list_filters.py
+++ b/psat_server_web/atlas/tests/atlasapi/test_object_list_filters.py
@@ -2,7 +2,7 @@ import unittest
 
 from django.test import TestCase
 
-from atlasapi.serializers import ObjectListSerializer
+from atlasapi.serializers import ObjectListSerializer, TcsObjectGroupsListSerializer
 from atlas.apiutils import buildObjectListQueryFilter
 
 
@@ -54,6 +54,30 @@ class TestObjectListSerializerFilters(TestCase):
         self.assertTrue(serializer.is_valid(), serializer.errors)
         self.assertEqual(serializer.validated_data['sherlock_class'], 'SN')
         self.assertEqual(serializer.validated_data['spec_type'], 'confirmed')
+
+
+class TestTcsObjectGroupsListSerializerFilters(TestCase):
+    def test_filters_default_to_none_when_absent(self):
+        serializer = TcsObjectGroupsListSerializer(data={})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        for field in NEW_FILTER_FIELDS:
+            self.assertIsNone(serializer.validated_data[field])
+
+    def test_numeric_and_string_filters_accept_values(self):
+        data = {
+            'objectgroupid': 3,
+            'vra_gte': 0.8, 'rb_pix_lte': 0.9,
+            'sherlock_class': 'SN', 'spec_type': 'confirmed',
+        }
+        serializer = TcsObjectGroupsListSerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(serializer.validated_data['vra_gte'], 0.8)
+        self.assertEqual(serializer.validated_data['sherlock_class'], 'SN')
+
+    def test_numeric_filter_rejects_non_numeric_value(self):
+        serializer = TcsObjectGroupsListSerializer(data={'vra_gte': 'not-a-number'})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('vra_gte', serializer.errors)
 
 
 class TestBuildObjectListQueryFilter(unittest.TestCase):


### PR DESCRIPTION
Added to the serializer

```
vra_gte = serializers.FloatField(required=False, default=None)
    vra_lte = serializers.FloatField(required=False, default=None)
    rb_pix_gte = serializers.FloatField(required=False, default=None)
    rb_pix_lte = serializers.FloatField(required=False, default=None)
    ra_gte = serializers.FloatField(required=False, default=None)
    ra_lte = serializers.FloatField(required=False, default=None)
    dec_gte = serializers.FloatField(required=False, default=None)
    dec_lte = serializers.FloatField(required=False, default=None)
    sherlock_class = serializers.CharField(required=False, default=None)
    spec_type = serializers.CharField(required=False, default=None)
```

Also removed the possibility for someone to request the entire table. 
Now API will throw an error if didn't request with either an object id or an object group id